### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,15 +2,16 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-
   private
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"] 
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
   end
+
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :birthday])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -42,7 +42,6 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    @item = Item.find(params[:id])
     unless current_user == @item.user
       redirect_to action: :index
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,13 +1,13 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index,:show]
+  before_action :authenticate_user!, except: [:index, :show]
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new
     @item = Item.new
   end
-  
+
   def create
     @item = Item.new(item_params)
     if @item.save
@@ -34,10 +34,10 @@ class ItemsController < ApplicationController
     end
   end
 
-
   private
 
   def item_params
-    params.require(:item).permit(:product_name,:text,:category_id,:condition_id,:shipping_fee_id,:prefecture_id,:shipping_day_id,:price,:image).merge(user_id: current_user.id)
+    params.require(:item).permit(:product_name, :text, :category_id, :condition_id, :shipping_fee_id, :prefecture_id, :shipping_day_id,
+                                 :price, :image).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_prototype, only: [:show, :edit, :update]
   before_action :move_to_index, except: [:index, :show, :new, :create]
 
   def index
@@ -20,15 +21,12 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -48,5 +46,9 @@ class ItemsController < ApplicationController
     unless current_user == @item.user
       redirect_to action: :index
     end
+  end
+
+  def set_item
+    @item = Item.find(params[:id])   
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :move_to_index, except: [:index, :show, :new, :create]
+
   def index
     @items = Item.includes(:user).order('created_at DESC')
   end
@@ -39,5 +41,12 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:product_name, :text, :category_id, :condition_id, :shipping_fee_id, :prefecture_id, :shipping_day_id,
                                  :price, :image).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    @item = Item.find(params[:id])
+    unless current_user == @item.user
+      redirect_to action: :index
+    end
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_prototype, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
   before_action :move_to_index, except: [:index, :show, :new, :create]
 
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,21 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
   end
+
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
+
+
   private
 
   def item_params

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,9 +13,7 @@ class Category < ActiveHash::Base
     { id: 11, name: 'ハンドメイド' },
     { id: 12, name: 'その他' }
   ]
- 
-include ActiveHash::Associations
-has_many :items
 
-
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -11,6 +11,4 @@ class Condition < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-
-
-  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,9 +10,10 @@ class Item < ApplicationRecord
   belongs_to :prefecture
 
   with_options presence: true do
-  validates :product_name,:text,:image
-  validates :category_id, :condition_id,  :shipping_day_id, :shipping_fee_id, :prefecture_id, numericality: { other_than: 1 , message: "can't be blank"} 
-  validates :price, numericality: {with: /\A[0-9]+\z/, message: "is invalid. Input half-width characters"}
-  validates :price, inclusion: {in: 300..9999999, message: "out of setting range"}
+    validates :product_name, :text, :image
+    validates :category_id, :condition_id, :shipping_day_id, :shipping_fee_id, :prefecture_id,
+              numericality: { other_than: 1, message: "can't be blank" }
+    validates :price, numericality: { with: /\A[0-9]+\z/, message: 'is invalid. Input half-width characters' }
+    validates :price, inclusion: { in: 300..9_999_999, message: 'out of setting range' }
   end
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,24 +1,22 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-    {id: 1, name: '--'}, {id: 2, name: '北海道'}, {id: 3, name: '青森県'}, 
-    {id: 4, name: '岩手県'}, {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, 
-    {id: 7, name: '山形県'}, {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, 
-    {id: 10, name: '栃木県'}, {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, 
-    {id: 13, name: '千葉県'}, {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, 
-    {id: 16, name: '新潟県'}, {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, 
-    {id: 19, name: '福井県'}, {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, 
-    {id: 22, name: '岐阜県'}, {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, 
-    {id: 25, name: '三重県'}, {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, 
-    {id: 28, name: '大阪府'}, {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, 
-    {id: 31, name: '和歌山県'}, {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, 
-    {id: 34, name: '岡山県'}, {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, 
-    {id: 37, name: '徳島県'}, {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, 
-    {id: 40, name: '高知県'}, {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, 
-    {id: 43, name: '長崎県'}, {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, 
-    {id: 46, name: '宮崎県'}, {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
-              ]
-              include ActiveHash::Associations
-              has_many :items
-
-
+    { id: 1, name: '--' }, { id: 2, name: '北海道' }, { id: 3, name: '青森県' },
+    { id: 4, name: '岩手県' }, { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' },
+    { id: 7, name: '山形県' }, { id: 8, name: '福島県' }, { id: 9, name: '茨城県' },
+    { id: 10, name: '栃木県' }, { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' },
+    { id: 13, name: '千葉県' }, { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' },
+    { id: 16, name: '新潟県' }, { id: 17, name: '富山県' }, { id: 18, name: '石川県' },
+    { id: 19, name: '福井県' }, { id: 20, name: '山梨県' }, { id: 21, name: '長野県' },
+    { id: 22, name: '岐阜県' }, { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' },
+    { id: 25, name: '三重県' }, { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' },
+    { id: 28, name: '大阪府' }, { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' },
+    { id: 31, name: '和歌山県' }, { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' },
+    { id: 34, name: '岡山県' }, { id: 35, name: '広島県' }, { id: 36, name: '山口県' },
+    { id: 37, name: '徳島県' }, { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' },
+    { id: 40, name: '高知県' }, { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' },
+    { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' }, { id: 45, name: '大分県' },
+    { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
+  ]
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/shipping_day.rb
+++ b/app/models/shipping_day.rb
@@ -8,6 +8,4 @@ class ShippingDay < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-
-
-  end
+end

--- a/app/models/shipping_fee.rb
+++ b/app/models/shipping_fee.rb
@@ -7,6 +7,4 @@ class ShippingFee < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-
-
-  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,11 +6,13 @@ class User < ApplicationRecord
 
   has_many :items
   has_many :purchases
-  
+
   with_options presence: true do
     validates :nickname, :birthday
-    validates :password,format:{with: /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i,message:"is invalid. Include both letters and numbers"}
-    validates :last_name, :first_name,format: {with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: "is invalid. Input full-width characters."}
-    validates :last_name_kana, :first_name_kana, format: {with: /\A[ァ-ヶー]+\z/, message: "is invalid. Input full-width katakana characters."}
+    validates :password,
+              format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'is invalid. Include both letters and numbers' }
+    validates :last_name, :first_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters.' }
+    validates :last_name_kana, :first_name_kana,
+              format: { with: /\A[ァ-ヶー]+\z/, message: 'is invalid. Input full-width katakana characters.' }
   end
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with(model: @item, local: true) do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :product_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :text, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_id, ShippingFee.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,6 +1,3 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
-
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
@@ -11,7 +8,6 @@ app/assets/stylesheets/items/new.css %>
 
     <%= render 'shared/error_messages', model: f.object %>
 
-    <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
         商品画像
@@ -24,8 +20,7 @@ app/assets/stylesheets/items/new.css %>
         <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
+   
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
@@ -40,9 +35,7 @@ app/assets/stylesheets/items/new.css %>
         <%= f.text_area :text, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
+   
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
@@ -58,9 +51,7 @@ app/assets/stylesheets/items/new.css %>
         <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
+    
     <div class="items-detail">
       <div class="weight-bold-text question-text">
         <span>配送について</span>
@@ -84,9 +75,7 @@ app/assets/stylesheets/items/new.css %>
         <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
+    
     <div class="sell-price">
       <div class="weight-bold-text question-text">
         <span>販売価格<br>(¥300〜9,999,999)</span>
@@ -115,9 +104,7 @@ app/assets/stylesheets/items/new.css %>
         </div>
       </div>
     </div>
-    <%# /販売価格 %>
-
-    <%# 注意書き %>
+   
     <div class="caution">
       <p class="sentence">
         <a href="#">禁止されている出品、</a>
@@ -135,13 +122,12 @@ app/assets/stylesheets/items/new.css %>
         に同意したことになります。
       </p>
     </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
+    
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
       <%=link_to 'もどる', "#", class:"back-btn" %>
     </div>
-    <%# /下部ボタン %>
+   
   </div>
   <% end %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,7 +1,6 @@
 <%= render "shared/header" %>
 <div class='main'>
 
-  <%# 画面上部の「人生を変えるフリマアプリ」帯部分 %>
   <div class='title-contents'>
     <h2 class='service-title'>
       人生を変えるフリマアプリ
@@ -17,9 +16,7 @@
       <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面上部の「人生を変えるフリマアプリ」帯部分  %>
-
-  <%# FURIMAが選ばれる3つの理由部分 %>
+  
   <div class='select-reason-contents'>
     <h2 class='title'>
       FURIMAが選ばれる3つの理由
@@ -60,9 +57,7 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAが選ばれる3つの理由部分 %>
-
-  <%# 画面中央の「会員数日本一位」帯部分 %>
+  
   <div class='ad-contents'>
     <h2 class='ad-title'>
       会員数日本一位
@@ -81,9 +76,7 @@
       <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
     </div>
   </div>
-  <%# /画面中央の「会員数日本一位」帯部分 %>
-
-  <%# FURIMAの特徴 %>
+  
   <div class='feature-contents'>
     <h2 class='title'>
       FURIMAの特徴
@@ -118,9 +111,7 @@
       </li>
     </ul>
   </div>
-  <%# /FURIMAの特徴 %>
 
-  <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <div class="subtitle" >
@@ -134,11 +125,11 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# 商品が売れていればsold outを表示しましょう 未実装のため残します%>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <%# //商品が売れていればsold outを表示しましょう 未実装のため残します%>
 
         </div>
         <div class='item-info'>
@@ -178,7 +169,7 @@
       <% end %>
     </ul>
   </div>
-  <%# /商品一覧 %>
+  
 </div>
 <%= link_to(new_item_path, class: 'purchase-btn') do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -9,7 +9,6 @@
 
     <%= render 'shared/error_messages', model: f.object %>
 
-    <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
         商品画像
@@ -22,8 +21,7 @@
         <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
-    <%# /商品画像 %>
-    <%# 商品名と商品説明 %>
+    
     <div class="new-items">
       <div class="weight-bold-text">
         商品名
@@ -38,9 +36,7 @@
         <%= f.text_area :text, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
-    <%# /商品名と商品説明 %>
-
-    <%# 商品の詳細 %>
+    
     <div class="items-detail">
       <div class="weight-bold-text">商品の詳細</div>
       <div class="form">
@@ -56,9 +52,7 @@
         <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
-    <%# /商品の詳細 %>
-
-    <%# 配送について %>
+    
     <div class="items-detail">
       <div class="weight-bold-text question-text">
         <span>配送について</span>
@@ -82,9 +76,7 @@
         <%= f.collection_select(:shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
-    <%# /配送について %>
-
-    <%# 販売価格 %>
+    
     <div class="sell-price">
       <div class="weight-bold-text question-text">
         <span>販売価格<br>(¥300〜9,999,999)</span>
@@ -113,9 +105,7 @@
         </span>
       </div>
     </div>
-    <%# /販売価格 %>
-
-    <%# 注意書き %>
+    
     <div class="caution">
       <p class="sentence">
         <a href="#">禁止されている出品、</a>
@@ -133,13 +123,12 @@
         に同意したことになります。
       </p>
     </div>
-    <%# /注意書き %>
-    <%# 下部ボタン %>
+    
     <div class="sell-btn-contents">
       <%= f.submit "出品する" ,class:"sell-btn" %>
       <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
-    <%# /下部ボタン %>
+    
   </div>
   <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? %>  
     <% if current_user.id == @item.user_id %> 
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,6 +1,5 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
@@ -8,11 +7,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# 商品が売れている場合は、sold outを表示しましょう 未実装のため残します%>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%# //商品が売れている場合は、sold outを表示しましょう 未実装のため残します%>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -77,7 +76,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,3 @@
-<%# 下部広告部分 %>
 <div class='ad-footer-contents'>
   <p class='ad-footer-explain'>
     だれでもかんたん、人生を変えるフリマアプリ
@@ -11,7 +10,7 @@
     <%= link_to image_tag("google-play.png", class:"google-btn"), "#" %>
   </div>
 </div>
-<%# /下部広告部分 %>
+
 
 <div class='footer'>
   <div class='footer-contents'>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,3 @@
-<%# CSS・・・assets/stylesheets/shared/header.css %>
 <header class='top-page-header'>
   <div class='search-bar-contents'>
     <%= link_to image_tag("furima-logo-color.png", class:"furima-icon"), "/" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
    root to: "items#index"
-   resources :items, only: [:new,:create,:show]
+   resources :items, only: [:new,:create,:show,:edit,:update]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :item do
-    product_name       {Faker::Lorem.sentence}
-    text               {Faker::Lorem.sentence}
-    price              {300}
-    image              {Faker::Lorem.sentence}
-    category_id        {2}
-    condition_id       {2}
-    shipping_day_id    {2}
-    shipping_fee_id    {2}
-    prefecture_id      {2} 
+    product_name       { Faker::Lorem.sentence }
+    text               { Faker::Lorem.sentence }
+    price              { 300 }
+    image              { Faker::Lorem.sentence }
+    category_id        { 2 }
+    condition_id       { 2 }
+    shipping_day_id    { 2 }
+    shipping_fee_id    { 2 }
+    prefecture_id      { 2 }
     association :user
 
     after(:build) do |item|

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,14 +1,13 @@
 FactoryBot.define do
   factory :user do
-    nickname              {"tarou"}
-    email                 {Faker::Internet.free_email}
-    password              {"12345a"}
-    password_confirmation {password}
-    first_name            {"太郎"}
-    last_name             {"桃"}
-    first_name_kana       {"タロウ"}
-    last_name_kana        {"モモ"}
-    birthday              {"2000-01-01"}
-
+    nickname              { 'tarou' }
+    email                 { Faker::Internet.free_email }
+    password              { '12345a' }
+    password_confirmation { password }
+    first_name            { '太郎' }
+    last_name             { '桃' }
+    first_name_kana       { 'タロウ' }
+    last_name_kana        { 'モモ' }
+    birthday              { '2000-01-01' }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,17 +5,17 @@ RSpec.describe Item, type: :model do
   end
 
   describe '商品出品機能' do
-    context '入力に問題がなければ商品の出品ができる'  do
+    context '入力に問題がなければ商品の出品ができる' do
       it '必須項目が全てあれば投稿できる' do
-      expect(@item).to be_valid 
+        expect(@item).to be_valid
       end
     end
-    context '入力に問題があれば商品の出品ができない'  do
+    context '入力に問題があれば商品の出品ができない' do
       it 'imageが空は出品できない' do
         @item.image = nil
         @item.valid?
         expect(@item.errors.full_messages).to include "Image can't be blank"
-       end
+      end
       it '商品名が空だと出品できない' do
         @item.product_name = ''
         @item.valid?
@@ -30,7 +30,7 @@ RSpec.describe Item, type: :model do
         @item.category_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Category can't be blank"
-       end
+      end
       it 'conditionが未選択だと出品できない' do
         @item.condition_id = ''
         @item.valid?
@@ -45,17 +45,17 @@ RSpec.describe Item, type: :model do
         @item.prefecture_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Prefecture can't be blank"
-       end
+      end
       it 'shipping_dayが未選択だと出品できない' do
         @item.shipping_day_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Shipping day can't be blank"
       end
-       it 'categoryが1では出品できない' do
+      it 'categoryが1では出品できない' do
         @item.category_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include "Category can't be blank"
-       end
+      end
       it 'conditionが1では出品できない' do
         @item.condition_id = 1
         @item.valid?
@@ -70,7 +70,7 @@ RSpec.describe Item, type: :model do
         @item.prefecture_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include "Prefecture can't be blank"
-       end
+      end
       it 'shipping_dayが1では出品できない' do
         @item.shipping_day_id = 1
         @item.valid?
@@ -79,22 +79,24 @@ RSpec.describe Item, type: :model do
       it 'priceが空だと出品できない' do
         @item.price = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price can't be blank", "Price is invalid. Input half-width characters", "Price can't be blank", "Price out of setting range"
+        expect(@item.errors.full_messages).to include "Price can't be blank", 'Price is invalid. Input half-width characters',
+                                                      "Price can't be blank", 'Price out of setting range'
       end
       it 'priceが下限(300)未満では出品できない' do
         @item.price = 100
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price out of setting range"
+        expect(@item.errors.full_messages).to include 'Price out of setting range'
       end
       it 'priceが上限(9999999)を超えると出品できない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price out of setting range"
+        expect(@item.errors.full_messages).to include 'Price out of setting range'
       end
       it 'priceが全角数字では出品できない' do
         @item.price = '３００'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is invalid. Input half-width characters", "Price out of setting range"
+        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters',
+                                                      'Price out of setting range'
       end
       it '出品者の情報が空の場合出品できない' do
         @item.user = nil

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,23 +31,24 @@ RSpec.describe User, type: :model do
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include "Email has already been taken"
+        expect(another_user.errors.full_messages).to include 'Email has already been taken'
       end
       it 'emailに＠が含まれていない場合は登録できない' do
         @user.email = 'sample.com'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Email is invalid"
+        expect(@user.errors.full_messages).to include 'Email is invalid'
       end
       it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password can't be blank","Password is invalid. Include both letters and numbers","Password confirmation doesn't match Password"
+        expect(@user.errors.full_messages).to include "Password can't be blank",
+                                                      'Password is invalid. Include both letters and numbers', "Password confirmation doesn't match Password"
       end
       it 'passwordが5文字以下では登録できない' do
         @user.password = '0000a'
         @user.password_confirmation = '0000a'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is too short (minimum is 6 characters)"
+        expect(@user.errors.full_messages).to include 'Password is too short (minimum is 6 characters)'
       end
       it 'passwordとpassword_confirmationが不一致では登録できないこと' do
         @user.password = '12345a'
@@ -59,73 +60,73 @@ RSpec.describe User, type: :model do
         @user.password = '123456'
         @user.password_confirmation = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is invalid. Include both letters and numbers"
+        expect(@user.errors.full_messages).to include 'Password is invalid. Include both letters and numbers'
       end
-       it 'passwordとpassword_confirmationが英語だけでは登録できないこと' do
+      it 'passwordとpassword_confirmationが英語だけでは登録できないこと' do
         @user.password = 'aaaaaa'
         @user.password_confirmation = 'aaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is invalid. Include both letters and numbers"
-       end
+        expect(@user.errors.full_messages).to include 'Password is invalid. Include both letters and numbers'
+      end
       it 'last_nameが空では登録できないこと' do
         @user.last_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name can't be blank", "Last name is invalid. Input full-width characters."
+        expect(@user.errors.full_messages).to include "Last name can't be blank",
+                                                      'Last name is invalid. Input full-width characters.'
       end
       it 'first_nameが空では登録できないこと' do
         @user.first_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name can't be blank", "First name is invalid. Input full-width characters."
+        expect(@user.errors.full_messages).to include "First name can't be blank",
+                                                      'First name is invalid. Input full-width characters.'
       end
       it 'last_nameが英字のみでは登録できないこと' do
         @user.last_name = 'a'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name is invalid. Input full-width characters."
+        expect(@user.errors.full_messages).to include 'Last name is invalid. Input full-width characters.'
       end
       it 'first_nameが英字のみでは登録できないこと' do
         @user.first_name = 'a'
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name is invalid. Input full-width characters."
+        expect(@user.errors.full_messages).to include 'First name is invalid. Input full-width characters.'
       end
       it 'last_name_kanaが空では登録できないこと' do
         @user.last_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name kana can't be blank", "Last name kana is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include "Last name kana can't be blank",
+                                                      'Last name kana is invalid. Input full-width katakana characters.'
       end
       it 'first_name_kanaが空では登録できないこと' do
         @user.first_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name kana can't be blank", "First name kana is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include "First name kana can't be blank",
+                                                      'First name kana is invalid. Input full-width katakana characters.'
       end
       it 'last_name_kanaがひらがなでは登録できないこと' do
         @user.last_name_kana = 'あ'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name kana is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include 'Last name kana is invalid. Input full-width katakana characters.'
       end
       it 'first_name_kanaがひらがなでは登録できないこと' do
         @user.first_name_kana = 'あ'
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name kana is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include 'First name kana is invalid. Input full-width katakana characters.'
       end
       it 'last_name_kanaが英字のみでは登録できないこと' do
         @user.last_name_kana = 'a'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name kana is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include 'Last name kana is invalid. Input full-width katakana characters.'
       end
       it 'first_name_kanaが英字のみでは登録できないこと' do
         @user.first_name_kana = 'a'
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name kana is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include 'First name kana is invalid. Input full-width katakana characters.'
       end
       it 'birthdayが空では登録できない' do
         @user.birthday = ''
         @user.valid?
         expect(@user.errors.full_messages).to include "Birthday can't be blank"
       end
-
     end
   end
 end
- 
-
-

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,9 +1,8 @@
 require 'test_helper'
 
 class ItemsControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
+  test 'should get index' do
     get items_index_url
     assert_response :success
   end
-
 end


### PR DESCRIPTION
# What
商品情報編集画面の作成

# Why
商品情報編集画面機能を実装するため

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/c74f0c4b1992b98ddc0ebbf55f05f5d0

必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/bd3c3fc17a8106ea305de683c427c0f0

入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/02033ec38586954a0e82142129ebdf7b

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/ce4a51e963c916f8d44defb3981367e6

ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/d2f089301e2baef1059c5f6714882eaf

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/495621680c22b7a336c0a6aa6f3f363c

商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/d450c7122a6028dac01fa7b08fd70a6f

よろしくお願いします。